### PR TITLE
Attempt config.xml update fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,7 +76,9 @@ Vagrant.configure(2) do |config|
 	apt-get install -y go-server
 
 	# Put our config file in place
+	/etc/init.d/go-server stop
 	/bin/bash /vagrant/update_config.sh
+	/etc/init.d/go-server start
 
 	apt-get install -y go-agent
 	/etc/init.d/go-agent start

--- a/update_config.sh
+++ b/update_config.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -x
 
         # Put our config file in place
         OLD_ID=$(sed -n 's/.*serverId="\([^"]*\)".*/\1/p' /etc/go/cruise-config.xml)


### PR DESCRIPTION
I suspect the config.xml wasn't updated because the server was already
running. So I shut it down before copying the config into place, then
start it back up.

For good measure, also have the config update script output its actions
(set -x), and exit with failure if any of its actions fail (set -e).
